### PR TITLE
{compiler,lib}/rb: Add support for middlewares and providers (client + processor) in the ruby stubs

### DIFF
--- a/compiler/cpp/src/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/generate/t_rb_generator.cc
@@ -892,7 +892,7 @@ void t_rb_generator::generate_service_client(t_service* tservice) {
 
   f_service_.indent() << "def initialize(client)" << endl;
   f_service_.indent_up();
-  f_service_.indent() << "@client = client" << endl;
+  f_service_.indent() << "@client = Thrift.build_client(client)" << endl;
   f_service_.indent_down();
   f_service_.indent() << "end" << endl << endl;
 

--- a/compiler/cpp/src/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/generate/t_rb_generator.cc
@@ -824,6 +824,8 @@ void t_rb_generator::generate_service(t_service* tservice) {
   generate_service_server(tservice);
   generate_service_helpers(tservice);
 
+  f_service_.indent() << "::Thrift.register_service_type(self)"<< endl << endl;
+
   f_service_.indent_down();
   f_service_.indent() << "end" << endl << endl;
 

--- a/compiler/cpp/src/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/generate/t_rb_generator.cc
@@ -1007,9 +1007,9 @@ void t_rb_generator::generate_service_server(t_service* tservice) {
 
   f_service_.indent() << "include ::Thrift::Processor" << endl << endl;
 
-  f_service_.indent() << "def self.from_provider(provider)" << endl;
+  f_service_.indent() << "def self.from_provider(handler, provider)" << endl;
   f_service_.indent_up();
-  f_service_.indent() << "Processor.new(provider.build(NAMESPACE, SERVICE))" << endl;
+  f_service_.indent() << "provider.build(NAMESPACE, SERVICE, Processor, handler)" << endl;
   f_service_.indent_down();
   f_service_.indent() << "end" << endl << endl;
 

--- a/compiler/cpp/src/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/generate/t_rb_generator.cc
@@ -588,8 +588,8 @@ void t_rb_generator::generate_rb_struct(t_rb_ofstream& out,
     generate_rb_simple_exception_constructor(out, tstruct);
   }
 
-  out.indent() << "NAME      = \"" << tstruct->get_name() << "\".freeze" << endl;
-  out.indent() << "NAMESPACE = \"" << tstruct->get_program()->get_namespace("*") << "\".freeze" << endl << endl;
+  out.indent() << "NAME = '" << tstruct->get_name() << "'.freeze" << endl;
+  out.indent() << "NAMESPACE = '" << tstruct->get_program()->get_namespace("*") << "'.freeze" << endl << endl;
 
   generate_field_constants(out, tstruct);
   generate_field_defns(out, tstruct);
@@ -615,8 +615,8 @@ void t_rb_generator::generate_rb_union(t_rb_ofstream& out,
   out.indent_up();
   out.indent() << "include ::Thrift::Struct_Union" << endl << endl;
 
-  out.indent() << "NAME      = \"" << tstruct->get_name() << "\".freeze" << endl;
-  out.indent() << "NAMESPACE = \"" << tstruct->get_program()->get_namespace("*") << "\".freeze" << endl << endl;
+  out.indent() << "NAME = '" << tstruct->get_name() << "'.freeze" << endl;
+  out.indent() << "NAMESPACE = '" << tstruct->get_program()->get_namespace("*") << "'.freeze" << endl << endl;
 
   generate_field_constructors(out, tstruct);
 
@@ -687,7 +687,7 @@ void t_rb_generator::generate_field_constants(t_rb_ofstream& out, t_struct* tstr
     std::string field_name = (*f_iter)->get_name();
     std::string cap_field_name = upcase_string(field_name);
 
-    out.indent() << cap_field_name << " = " << (*f_iter)->get_key() << endl;
+    out.indent() << "THRIFT_FIELD_INDEX_" << cap_field_name << " = " << (*f_iter)->get_key() << endl;
   }
   out << endl;
 }
@@ -706,7 +706,7 @@ void t_rb_generator::generate_field_defns(t_rb_ofstream& out, t_struct* tstruct)
     // generate the field docstrings within the FIELDS constant. no real better place...
     generate_rdoc(out, *f_iter);
 
-    out.indent() << upcase_string((*f_iter)->get_name()) << " => ";
+    out.indent() << "THRIFT_FIELD_INDEX_" << upcase_string((*f_iter)->get_name()) << " => ";
 
     generate_field_data(out,
                         (*f_iter)->get_type(),
@@ -729,44 +729,44 @@ void t_rb_generator::generate_field_data(t_rb_ofstream& out,
   field_type = get_true_type(field_type);
 
   // Begin this field's defn
-  out << "{:type => " << type_to_enum(field_type);
+  out << "{type: " << type_to_enum(field_type);
 
   if (!field_name.empty()) {
-    out << ", :name => '" << field_name << "'";
+    out << ", name: '" << field_name << "'";
   }
 
   if (field_value != NULL) {
-    out << ", :default => ";
+    out << ", default: ";
     render_const_value(out, field_type, field_value);
   }
 
   if (!field_type->is_base_type()) {
     if (field_type->is_struct() || field_type->is_xception()) {
-      out << ", :class => " << full_type_name((t_struct*)field_type);
+      out << ", class: " << full_type_name((t_struct*)field_type);
     } else if (field_type->is_list()) {
-      out << ", :element => ";
+      out << ", element: ";
       generate_field_data(out, ((t_list*)field_type)->get_elem_type());
     } else if (field_type->is_map()) {
-      out << ", :key => ";
+      out << ", key: ";
       generate_field_data(out, ((t_map*)field_type)->get_key_type());
-      out << ", :value => ";
+      out << ", value: ";
       generate_field_data(out, ((t_map*)field_type)->get_val_type());
     } else if (field_type->is_set()) {
-      out << ", :element => ";
+      out << ", element: ";
       generate_field_data(out, ((t_set*)field_type)->get_elem_type());
     }
   } else {
     if (((t_base_type*)field_type)->is_binary()) {
-      out << ", :binary => true";
+      out << ", binary: true";
     }
   }
 
   if (optional) {
-    out << ", :optional => true";
+    out << ", optional: true";
   }
 
   if (field_type->is_enum()) {
-    out << ", :enum_class => " << full_type_name(field_type);
+    out << ", enum_class: " << full_type_name(field_type);
   }
 
   // End of this field's defn
@@ -816,8 +816,8 @@ void t_rb_generator::generate_service(t_service* tservice) {
 
   f_service_.indent() << "module " << capitalize(tservice->get_name()) << endl;
   f_service_.indent_up();
-  f_service_.indent() << "SERVICE   = \"" << tservice->get_name() << "\".freeze" << endl;
-  f_service_.indent() << "NAMESPACE = \"" << tservice->get_program()->get_namespace("*") << "\".freeze" << endl << endl;
+  f_service_.indent() << "SERVICE = '" << tservice->get_name() << "'.freeze" << endl;
+  f_service_.indent() << "NAMESPACE = '" << tservice->get_program()->get_namespace("*") << "'.freeze" << endl << endl;
 
   // Generate the three main parts of the service (well, two for now in PHP)
   generate_service_client(tservice);

--- a/lib/rb/lib/thrift/client.rb
+++ b/lib/rb/lib/thrift/client.rb
@@ -20,17 +20,9 @@
 
 module Thrift
   module Client
-    def initialize(iprot, middlewares = [], oprot = nil)
+    def initialize(iprot, oprot = nil)
       @iprot = iprot
       @oprot = oprot || iprot
-      @middleware = case middlewares.length
-                    when 0
-                      Middleware::NOP_MIDDLEWARE
-                    when 1
-                      middlewares.first
-                    else
-                      Middleware::MultiMiddleware.new(middlewares)
-                    end
       @seqid = 0
     end
 
@@ -48,9 +40,15 @@ module Thrift
 
     def send_message_args(args_class, args)
       data = args_class.new
+
       args.each do |k, v|
         data.send("#{k.to_s}=", v)
       end
+
+      send_message_instance(data)
+    end
+
+    def send_message_instance(data)
       begin
         data.write(@oprot)
       rescue StandardError => e

--- a/lib/rb/lib/thrift/client.rb
+++ b/lib/rb/lib/thrift/client.rb
@@ -93,4 +93,27 @@ module Thrift
       raise x
     end
   end
+
+  class BaseClient
+    include Client
+
+    def call_unary(name, req)
+      @oprot.write_message_begin(name, Thrift::MessageTypes::ONEWAY, @seqid)
+      send_message_instance(req)
+    end
+
+    def call_binary(name, req, resp_klass)
+      @oprot.write_message_begin(name, Thrift::MessageTypes::CALL, @seqid)
+      send_message_instance(req)
+      receive_message(resp_klass)
+    end
+  end
+
+  class << self
+    def build_client(input)
+      return BaseClient.new(input) if input.is_a? BaseProtocol
+
+      input
+    end
+  end
 end

--- a/lib/rb/lib/thrift/definition.rb
+++ b/lib/rb/lib/thrift/definition.rb
@@ -1,24 +1,64 @@
 module Thrift
   class StructDefinition
-    attr_reader :namespace, :name, :klass
+    attr_reader :klass
+
     def initialize(klass)
-      @namespace = klass::NAMESPACE
-      @name = klass::NAME
       @klass = klass
     end
 
+    def namespace
+      @klass::NAMESPACE
+    end
+
+    def name
+      @klass::NAME
+    end
+
     def struct_type
-      "#{@namespace}.#{@name}"
+      "#{namespace}.#{name}"
+    end
+  end
+
+  class ServiceDefinition < StructDefinition
+    attr_reader :klass
+
+    def initialize(klass)
+      @klass = klass
+    end
+
+    def client_class
+      @klass::Client
+    end
+
+    def processor_class
+      @klass::Processor
+    end
+
+    def namespace
+      @klass::NAMESPACE
+    end
+
+    def service
+      @klass::SERVICE
+    end
+
+    def service_type
+      "#{namespace}.#{service}"
     end
   end
 
   STRUCT_DEFINITIONS = {}
+  SERVICE_DEFINITIONS = {}
 
   class << self
-
     def register_struct_type(klass)
       definition = StructDefinition.new(klass)
       STRUCT_DEFINITIONS[definition.struct_type] = definition
+    end
+
+    def register_service_type(klass)
+      definition = ServiceDefinition.new(klass)
+      SERVICE_DEFINITIONS[definition.service_type] = definition
     end
   end
 end

--- a/lib/rb/lib/thrift/middleware.rb
+++ b/lib/rb/lib/thrift/middleware.rb
@@ -33,5 +33,18 @@ module Thrift
     end
 
     NOP_MIDDLEWARE = NopMiddleware.new
+
+    class << self
+      def wrap(middlewares)
+        case middlewares.length
+        when 0
+          NOP_MIDDLEWARE
+        when 1
+          middlewares.first
+        else
+          MultiMiddleware.new(middlewares)
+        end
+      end
+    end
   end
 end

--- a/lib/rb/lib/thrift/processor.rb
+++ b/lib/rb/lib/thrift/processor.rb
@@ -21,14 +21,7 @@ module Thrift
   module Processor
     def initialize(handler, middlewares = [])
       @handler = handler
-      @middleware = case middlewares.length
-                    when 0
-                      Middleware::NOP_MIDDLEWARE
-                    when 1
-                      middlewares.first
-                    else
-                      Middleware::MultiMiddleware.new(middlewares)
-                    end
+      @middleware = Middleware.wrap(middlewares)
     end
 
     def process(iprot, oprot)
@@ -46,7 +39,7 @@ module Thrift
         write_exception(
           ApplicationException.new(
             ApplicationException::UNKNOWN_METHOD,
-            'Unknown function '+name,
+            'Unknown function ' + name,
           ),
           oprot,
           name,

--- a/lib/rb/lib/thrift/struct.rb
+++ b/lib/rb/lib/thrift/struct.rb
@@ -1,4 +1,4 @@
-# 
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements. See the NOTICE file
 # distributed with this work for additional information
@@ -6,16 +6,16 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License. You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# 
+#
 
 require 'set'
 
@@ -24,15 +24,15 @@ module Thrift
     def initialize(d={}, &block)
       # get a copy of the default values to work on, removing defaults in favor of arguments
       fields_with_defaults = fields_with_default_values.dup
-      
-      # check if the defaults is empty, or if there are no parameters for this 
+
+      # check if the defaults is empty, or if there are no parameters for this
       # instantiation, and if so, don't bother overriding defaults.
       unless fields_with_defaults.empty? || d.empty?
         d.each_key do |name|
           fields_with_defaults.delete(name.to_s)
         end
       end
-      
+
       # assign all the user-specified arguments
       unless d.empty?
         d.each do |name, value|
@@ -43,14 +43,14 @@ module Thrift
           instance_variable_set("@#{name}", value)
         end
       end
-      
+
       # assign all the default values
       unless fields_with_defaults.empty?
         fields_with_defaults.each do |name, default_value|
           instance_variable_set("@#{name}", (default_value.dup rescue default_value))
         end
       end
-      
+
       yield self if block_given?
     end
 
@@ -67,7 +67,7 @@ module Thrift
       end
       fields_with_default_values
     end
-    
+
     def inspect(skip_optional_nulls = true)
       fields = []
       each_field do |fid, field_info|

--- a/lib/rb/lib/thrift/transport/server_socket.rb
+++ b/lib/rb/lib/thrift/transport/server_socket.rb
@@ -1,5 +1,5 @@
 # encoding: ascii-8bit
-# 
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements. See the NOTICE file
 # distributed with this work for additional information
@@ -7,16 +7,16 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License. You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# 
+#
 
 require 'socket'
 
@@ -37,7 +37,7 @@ module Thrift
     attr_reader :handle
 
     def listen
-      @handle = TCPServer.new(@host, @port)
+      @handle ||= TCPServer.new(@host, @port)
     end
 
     def accept


### PR DESCRIPTION
### What does this PR do?

In order to bring feature parity in between the thrift stack in Go and in Ruby, i added the support for:

* Middleware: will allow us to have consistent metrics (via prometheus)   (cf. uthrift-ruby), distributed tracing, passing around metadata deadline etc... (compatible with the go impl)
* ClientProvider: It will allow us to do centralized service discovery (using UDS) (no more hard coded transport + protocol)

### What are the observable changes?

N/A

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests ( the integration testing will is done in uthrift-ruby )
