### PR TITLE
Add options to `from_provider` build factory.

### DIFF
--- a/compiler/cpp/src/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/generate/t_rb_generator.cc
@@ -902,9 +902,9 @@ void t_rb_generator::generate_service_client(t_service* tservice) {
   f_service_.indent_down();
   f_service_.indent() << "end" << endl << endl;
 
-  f_service_.indent() << "def self.from_provider(provider)" << endl;
+  f_service_.indent() << "def self.from_provider(provider, opts = {})" << endl;
   f_service_.indent_up();
-  f_service_.indent() << "Client.new(provider.build(NAMESPACE, SERVICE))" << endl;
+  f_service_.indent() << "Client.new(provider.build(NAMESPACE, SERVICE, opts))" << endl;
   f_service_.indent_down();
   f_service_.indent() << "end" << endl << endl;
 


### PR DESCRIPTION
### What does this PR do ?

This PR changes the compiler to allow the caller to pass down an `opts` hash when calling `from_provider`.

We have sometimes multiple implementations of the same service so differentiating only by service key is not sufficient.
To allow the client provider to build the right transport instance, this PR adds a optional `opts` hash which allows to provide additional metadata about the service we want to talk to.

For example,

```rb
# Calling this
SomeService::Client.from_provider(client_provider, {some: metadata})

# Allows the ClientProvider to do.
def build(service,  namespace, opts) 
   # Pick the right provider based on the service, namespace and optional metadata.
end
```

:warning: That's a BC with current ClientProvider implementations. The other non BC options I have is to change the compiler so it generates the following code instead.

```rb
def from_provider(provider, opts ={}) 
  p = if opts.nil? 
    provider.build(NAMESPACE, SERVICE)
  else
    provider.build_with_options(NAMESPACE, SERVICE, opts)
  end
  Client.new(p)
end
```