### PR TITLE
Vague attempt to build on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,21 +21,43 @@ jobs:
         uses: actions/checkout@v2
       - name: Generate build configuration
         run: |
-          cmake -DBUILD_COMPILER=ON -DBUILD_LIBRARIES=OFF -DBUILD_TESTING=OFF \
-                -DBUILD_EXAMPLES=OFF -DTYPES_PREFIX=/home/runner/work .
+          cmake \
+            -DBUILD_COMPILER=ON \
+            -DBUILD_LIBRARIES=OFF \
+            -DBUILD_TESTING=OFF \
+            -DBUILD_EXAMPLES=OFF
       - name: Build
         run: |
           cmake --build . --config Release
-      # - name: Get Package Version
-      #   if: contains(github.ref, 'refs/tags/v')
-      #   id: pkg_version
-      #   run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
-      # - name: Create a new Release
-      #   if: contains(github.ref, 'refs/tags/v')
-      #   uses: "marvinpinto/action-automatic-releases@v1.2.1"
-      #   with:
-      #     repo_token: "${{ secrets.GITHUB_TOKEN }}"
-      #     automatic_release_tag: "${{ steps.pkg_version.outputs.VERSION }}"
-      #     title: "${{ steps.pkg_version.outputs.VERSION }}"
-      #     files: |
-      #       bin/thrift
+          mv bin/thrift bin/thrift-${{ matrix.os }}
+      - name: Upload Binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: thrift-${{ matrix.os }}
+          retention-days: 1
+          path: |
+            bin/*
+
+  release:
+    name: "Release binaries"
+    runs-on: ubuntu-20.04
+    needs: build
+    if: contains(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: thrift-ubuntu-20.04
+      - uses: actions/download-artifact@v2
+        with:
+          name: thrift-macos-10.15
+      - name: Get Package Version
+        id: pkg_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+      - name: Create a new Release
+        uses: marvinpinto/action-automatic-releases@v1.2.1
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          automatic_release_tag: ${{ steps.pkg_version.outputs.VERSION }}
+          title: ${{ steps.pkg_version.outputs.VERSION }}
+          files: |
+            bin/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'v1.x'
+      - 'v2.x'
+    tags:
+      - v*
+
+jobs:
+  build:
+    name: Build the thrift compiler
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-10.15]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Generate build configuration
+        run: |
+          cmake -DBUILD_COMPILER=ON -DBUILD_LIBRARIES=OFF -DBUILD_TESTING=OFF \
+                -DBUILD_EXAMPLES=OFF -DTYPES_PREFIX=/home/runner/work .
+      - name: Build
+        run: |
+          cmake --build . --config Release
+      # - name: Get Package Version
+      #   if: contains(github.ref, 'refs/tags/v')
+      #   id: pkg_version
+      #   run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+      # - name: Create a new Release
+      #   if: contains(github.ref, 'refs/tags/v')
+      #   uses: "marvinpinto/action-automatic-releases@v1.2.1"
+      #   with:
+      #     repo_token: "${{ secrets.GITHUB_TOKEN }}"
+      #     automatic_release_tag: "${{ steps.pkg_version.outputs.VERSION }}"
+      #     title: "${{ steps.pkg_version.outputs.VERSION }}"
+      #     files: |
+      #       bin/thrift


### PR DESCRIPTION
### What does this PR do ?

In an effort to:
1. Gain time on upfluence-if build
2. Ditch circle CI on upfluence-if

I'm trying to create a workflow a build and release a thrift compiler binary on this repository. To get a stable URL  so we can pull them from another job instead of installing them.

Also we could cross compile, but heh. 