### PR TITLE
lib/go/thrift: Allow TransportException to be unwrapped

### DIFF
--- a/lib/go/thrift/transport_exception.go
+++ b/lib/go/thrift/transport_exception.go
@@ -64,6 +64,10 @@ func (te *tTransportException) Err() error {
 	return te.err
 }
 
+func (te *tTransportException) Unwrap() error {
+	return te.err
+}
+
 func NewTTransportException(t int, e string) TTransportException {
 	return &tTransportException{typeId: t, err: errors.New(e)}
 }


### PR DESCRIPTION
This PR will allow us to do some errors introspection with `errors.Is` or `errors.As`. 

The end goal with that is to trim off all the errors from sentry that stem off of canceled requests