### PR TITLE
compiler/cpp/src/generate/t_json_generator: Handle enum with particular typeId

### DIFF
--- a/compiler/cpp/src/generate/t_json_generator.cc
+++ b/compiler/cpp/src/generate/t_json_generator.cc
@@ -239,7 +239,7 @@ void t_json_generator::end_array() {
 
 void t_json_generator::write_type_spec_object(const char* name, t_type* ttype) {
   ttype = ttype->get_true_type();
-  if (ttype->is_struct() || ttype->is_xception() || ttype->is_container()) {
+  if (ttype->is_struct() || ttype->is_xception() || ttype->is_container() || ttype->is_enum()) {
     write_key_and(name);
     start_object(NO_INDENT);
     write_key_and("typeId");
@@ -271,6 +271,8 @@ void t_json_generator::write_type_spec(t_type* ttype) {
     t_type* etype = ((t_list*)ttype)->get_elem_type();
     write_key_and_string("elemTypeId", get_type_name(etype));
     write_type_spec_object("elemType", etype);
+  } else if (ttype->is_enum()) {
+    write_key_and_string("class", get_qualified_name(ttype));
   }
 }
 
@@ -707,7 +709,7 @@ string t_json_generator::get_type_name(t_type* ttype) {
     return "map";
   }
   if (ttype->is_enum()) {
-    return "i32";
+    return "enum";
   }
   if (ttype->is_struct()) {
     return ((t_struct*)ttype)->is_union() ? "union" : "struct";


### PR DESCRIPTION
This PR changes the typeId returned in case of enum, insteadof being i32. Also the na e of the enum is serialized in the class object.