### PR TITLE
Handle the renaming of programs, services and structs.

### DIFF
--- a/compiler/cpp/Makefile.am
+++ b/compiler/cpp/Makefile.am
@@ -41,6 +41,7 @@ thrift_SOURCES = src/main.cc \
                  src/logging.h \
                  src/md5.h \
                  src/parse/t_doc.h \
+                 src/parse/t_name.h \
                  src/parse/t_type.h \
                  src/parse/t_base_type.h \
                  src/parse/t_enum.h \

--- a/compiler/cpp/src/generate/t_json_generator.cc
+++ b/compiler/cpp/src/generate/t_json_generator.cc
@@ -120,6 +120,7 @@ private:
   void write_type_spec(t_type* ttype);
   void write_string(const string& value);
   void write_value(t_type* tvalue);
+  void write_legacy_names(t_type* ttype);
   void write_const_value(t_const_value* value, bool force_string = false);
   void write_key_and(string key);
   void write_key_and_string(string key, string val);
@@ -571,6 +572,22 @@ void t_json_generator::generate_enum(t_enum* tenum) {
   end_object();
 }
 
+void t_json_generator::write_legacy_names(t_type* ttype) {
+  start_array();
+  vector<t_name*> names = ttype->get_legacy_names();
+
+  for (vector<t_name*>::iterator it = names.begin(); it != names.end(); ++it) {
+    write_comma_if_needed();
+  start_object();
+  write_key_and_string("namespace", (*it)->get_namespace());
+  write_key_and_string("name", (*it)->get_name());
+  end_object();
+    indicate_comma_needed();
+  }
+
+  end_array();
+}
+
 void t_json_generator::generate_struct(t_struct* tstruct) {
   start_object();
 
@@ -583,6 +600,9 @@ void t_json_generator::generate_struct(t_struct* tstruct) {
   write_key_and_bool("isException", tstruct->is_xception());
 
   write_key_and_bool("isUnion", tstruct->is_union());
+
+  write_key_and("legacyNames");
+  write_legacy_names((t_type*)tstruct);
 
   write_key_and("fields");
   start_array();
@@ -610,6 +630,9 @@ void t_json_generator::generate_service(t_service* tservice) {
   if (tservice->has_doc()) {
     write_key_and_string("doc", tservice->get_doc());
   }
+
+  write_key_and("legacyNames");
+  write_legacy_names((t_type*)tservice);
 
   write_key_and("functions");
   start_array();

--- a/compiler/cpp/src/generate/t_rb_generator.cc
+++ b/compiler/cpp/src/generate/t_rb_generator.cc
@@ -596,6 +596,15 @@ void t_rb_generator::generate_rb_struct(t_rb_ofstream& out,
   out.indent() << "NAME = '" << tstruct->get_name() << "'.freeze" << endl;
   out.indent() << "NAMESPACE = '" << tstruct->get_program()->get_namespace("*") << "'.freeze" << endl << endl;
 
+  out.indent() << "LEGACY_NAMES = [" << endl;
+  std::vector<t_name*> legacy_names = tstruct->get_legacy_names();
+  out.indent_up();
+  for (std::vector<t_name*>::iterator it = legacy_names.begin(); it != legacy_names.end(); ++it) {
+    out.indent() << "{ namespace: '" << (*it)->get_namespace() << "', name: '" << (*it)->get_name() << "' }," << endl;
+  }
+  out.indent_down();
+  out.indent() << "].freeze" << endl << endl;
+
   generate_field_constants(out, tstruct);
   generate_field_defns(out, tstruct);
   generate_rb_struct_required_validator(out, tstruct);
@@ -622,6 +631,15 @@ void t_rb_generator::generate_rb_union(t_rb_ofstream& out,
 
   out.indent() << "NAME = '" << tstruct->get_name() << "'.freeze" << endl;
   out.indent() << "NAMESPACE = '" << tstruct->get_program()->get_namespace("*") << "'.freeze" << endl << endl;
+
+  out.indent() << "LEGACY_NAMES = [" << endl;
+  std::vector<t_name*> legacy_names = tstruct->get_legacy_names();
+  out.indent_up();
+  for (std::vector<t_name*>::iterator it = legacy_names.begin(); it != legacy_names.end(); ++it) {
+    out.indent() << "{ namespace: '" << (*it)->get_namespace() << "', name: '" << (*it)->get_name() << "' }," << endl;
+  }
+  out.indent_down();
+  out.indent() << "].freeze" << endl << endl;
 
   generate_field_constructors(out, tstruct);
 
@@ -825,6 +843,15 @@ void t_rb_generator::generate_service(t_service* tservice) {
   f_service_.indent() << "SERVICE = '" << tservice->get_name() << "'.freeze" << endl;
   f_service_.indent() << "NAMESPACE = '" << tservice->get_program()->get_namespace("*") << "'.freeze" << endl << endl;
 
+  f_service_.indent() << "LEGACY_NAMES = [" << endl;
+  std::vector<t_name*> legacy_names = tservice->get_legacy_names();
+  f_service_.indent_up();
+  for (std::vector<t_name*>::iterator it = legacy_names.begin(); it != legacy_names.end(); ++it) {
+    f_service_.indent() << "{ namespace: '" << (*it)->get_namespace() << "', service: '" << (*it)->get_name() << "' }," << endl;
+  }
+  f_service_.indent_down();
+  f_service_.indent() << "].freeze" << endl << endl;
+
   // Generate the three main parts of the service (well, two for now in PHP)
   generate_service_helpers(tservice);
   generate_service_client(tservice);
@@ -904,7 +931,7 @@ void t_rb_generator::generate_service_client(t_service* tservice) {
 
   f_service_.indent() << "def self.from_provider(provider)" << endl;
   f_service_.indent_up();
-  f_service_.indent() << "Client.new(provider.build(NAMESPACE, SERVICE))" << endl;
+  f_service_.indent() << "Client.new(::Thrift.build_client_from_provider(" << full_type_name(tservice) << ", provider))" << endl;
   f_service_.indent_down();
   f_service_.indent() << "end" << endl << endl;
 
@@ -1015,7 +1042,7 @@ void t_rb_generator::generate_service_server(t_service* tservice) {
 
   f_service_.indent() << "def self.from_provider(handler, provider)" << endl;
   f_service_.indent_up();
-  f_service_.indent() << "provider.build(NAMESPACE, SERVICE, Processor, handler)" << endl;
+  f_service_.indent() << "::Thrift.build_processor_from_provider(" << full_type_name(tservice) << ", provider, handler)" << endl;
   f_service_.indent_down();
   f_service_.indent() << "end" << endl << endl;
 

--- a/compiler/cpp/src/parse/parse.cc
+++ b/compiler/cpp/src/parse/parse.cc
@@ -19,6 +19,7 @@
 
 #include "t_type.h"
 #include "t_typedef.h"
+#include "t_program.h"
 
 #include "md5.h"
 #include "main.h"
@@ -40,4 +41,19 @@ t_type* t_type::get_true_type() {
     type = ((t_typedef*)type)->get_type();
   }
   return type;
+}
+
+t_name* t_type::get_current_name() {
+  return new t_name(false, program_->get_namespace("*"), name_);
+}
+
+std::vector<t_name*> t_type::get_program_legacy_names() {
+  std::vector<t_name*> res;
+  std::vector<std::string> names = program_->get_legacy_names();
+
+  for (std::vector<std::string>::iterator it = names.begin(); it != names.end(); ++it) {
+    res.push_back(new t_name(true, *it, name_));
+  }
+
+  return res;
 }

--- a/compiler/cpp/src/parse/t_name.h
+++ b/compiler/cpp/src/parse/t_name.h
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef T_NAME_H
+#define T_NAME_H
+
+#include "globals.h"
+
+class t_name {
+public:
+  t_name(bool b) : is_legacy_(b) {}
+
+  t_name(bool b, std::string ns, std::string n) : namespace_(ns), name_(n), is_legacy_(b) {}
+
+  void set_namespace_(const std::string& n) { namespace_ = n; }
+  void set_name(const std::string& n) { name_ = n; }
+
+  const std::string& get_name() const { return name_; }
+  const std::string& get_namespace() const { return namespace_; }
+  bool is_legacy() const { return is_legacy_; }
+private:
+  std::string namespace_;
+  std::string name_;
+  bool is_legacy_;
+};
+
+class t_name_set {
+public:
+  void append(t_name* name) { names_.push_back(name); }
+
+  const std::vector<t_name*>& get_names() { return names_; }
+private:
+  std::vector<t_name*> names_;
+};
+
+#endif

--- a/compiler/cpp/src/parse/t_program.h
+++ b/compiler/cpp/src/parse/t_program.h
@@ -342,6 +342,9 @@ public:
 
   const std::vector<std::string>& get_c_includes() { return c_includes_; }
 
+  void add_legacy_name(std::string name) { legacy_names_.push_back(name); }
+
+  const std::vector<std::string>& get_legacy_names() { return legacy_names_; }
 private:
   // File path
   std::string path_;
@@ -387,6 +390,7 @@ private:
 
   // C extra includes
   std::vector<std::string> c_includes_;
+  std::vector<std::string> legacy_names_;
 };
 
 #endif

--- a/compiler/cpp/src/parse/t_type.h
+++ b/compiler/cpp/src/parse/t_type.h
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <stdint.h>
 #include "t_doc.h"
+#include "t_name.h"
 
 class t_program;
 
@@ -62,7 +63,32 @@ public:
 
   const t_program* get_program() const { return program_; }
 
+  t_name* get_current_name();
+  std::vector<t_name*> get_program_legacy_names();
+
   t_type* get_true_type();
+
+  std::vector<t_name*> get_legacy_names() {
+    std::vector<t_name*> res;
+
+    if (legacy_names_ != NULL) {
+      std::vector<t_name*> names = legacy_names_->get_names();
+
+      for(std::vector<t_name*>::iterator it = names.begin(); it != names.end(); ++it) {
+        res.push_back(*it);
+      }
+    }
+
+    if (program_ != NULL) {
+      std::vector<t_name*> names = get_program_legacy_names();
+
+      for(std::vector<t_name*>::iterator it = names.begin(); it != names.end(); ++it) {
+        res.push_back(*it);
+      }
+    }
+
+    return res;
+  }
 
   // Return a string that uniquely identifies this type
   // from any other thrift type in the world, as far as
@@ -119,9 +145,12 @@ public:
     return rv;
   }
 
-  std::map<std::string, std::string> annotations_;
+  void set_legacy_name_set(t_name_set* name_set) { legacy_names_ = name_set; }
 
+  std::map<std::string, std::string> annotations_;
 protected:
+  t_name_set* legacy_names_;
+
   t_type() : program_(NULL) { memset(fingerprint_, 0, sizeof(fingerprint_)); }
 
   t_type(t_program* program) : program_(program) { memset(fingerprint_, 0, sizeof(fingerprint_)); }

--- a/compiler/cpp/src/thriftl.ll
+++ b/compiler/cpp/src/thriftl.ll
@@ -131,7 +131,11 @@ literal_begin (['\"])
 "false"              { yylval.iconst=0; return tok_int_constant; }
 "true"               { yylval.iconst=1; return tok_int_constant; }
 
-"namespace"          { return tok_namespace;            }
+"namespace"            { return tok_namespace;   }
+"name"                 { return tok_name;        }
+"@previously_known_as" { return tok_legacy_name; }
+"previously_known_as"  { return tok_namespace_legacy_name; }
+
 "cpp_namespace"      { return tok_cpp_namespace;        }
 "cpp_include"        { return tok_cpp_include;          }
 "cpp_type"           { return tok_cpp_type;             }

--- a/lib/go/thrift/definition.go
+++ b/lib/go/thrift/definition.go
@@ -53,9 +53,18 @@ func (sd StructDefinition) CanonicalName() string {
 	return fmt.Sprintf("%s.%s", sd.Namespace, sd.Name)
 }
 
+type DefinedStruct interface {
+	StructDefinition() StructDefinition
+}
+
+type FullyDefinedStruct interface {
+	DefinedStruct
+	LegacyStructDefinitions() []StructDefinition
+}
+
 type RegistrableStruct interface {
 	TStruct
-	StructDefinition() StructDefinition
+	DefinedStruct
 }
 
 func RegisterStruct(rs RegistrableStruct) {

--- a/lib/go/thrift/provider.go
+++ b/lib/go/thrift/provider.go
@@ -1,9 +1,54 @@
 package thrift
 
+import "errors"
+
+var (
+	ErrClientNotDefined    = errors.New("client not defined")
+	ErrProcessorNotDefined = errors.New("processor not defined")
+)
+
 type TClientProvider interface {
 	Build(string, string) (TClient, error)
 }
 
+func BuildClient(cp TClientProvider, s FullyDefinedStruct) (TClient, error) {
+	defs := append(
+		[]StructDefinition{s.StructDefinition()},
+		s.LegacyStructDefinitions()...,
+	)
+
+	for _, def := range defs {
+		switch cl, err := cp.Build(def.Namespace, def.Name); {
+		case err == nil:
+			return cl, nil
+		case errors.Is(err, ErrClientNotDefined):
+		default:
+			return nil, err
+		}
+	}
+
+	return nil, ErrClientNotDefined
+}
+
 type TProcessorProvider interface {
 	Build(string, string) (TProcessor, error)
+}
+
+func BuildProcessor(pp TProcessorProvider, s FullyDefinedStruct) (TProcessor, error) {
+	defs := append(
+		[]StructDefinition{s.StructDefinition()},
+		s.LegacyStructDefinitions()...,
+	)
+
+	for _, def := range defs {
+		switch cl, err := pp.Build(def.Namespace, def.Name); {
+		case err == nil:
+			return cl, nil
+		case errors.Is(err, ErrProcessorNotDefined):
+		default:
+			return nil, err
+		}
+	}
+
+	return nil, ErrProcessorNotDefined
 }

--- a/lib/rb/lib/thrift/client.rb
+++ b/lib/rb/lib/thrift/client.rb
@@ -115,5 +115,20 @@ module Thrift
 
       input
     end
+
+    def build_client_from_provider(klass, provider)
+      sdef = ServiceDefinition.new(klass)
+
+      [
+        { namespace: sdef.namespace, service: sdef.service },
+        *sdef.legacy_names
+      ].reduce(nil) do |acc, n|
+        acc || begin
+          provider.build(n[:namespace], n[:service])
+        rescue ClientNotDefined
+          nil
+        end
+      end || raise(ClientNotDefined)
+    end
   end
 end

--- a/lib/rb/lib/thrift/definition.rb
+++ b/lib/rb/lib/thrift/definition.rb
@@ -17,6 +17,12 @@ module Thrift
     def struct_type
       "#{namespace}.#{name}"
     end
+
+    def legacy_names
+      return [] unless @klass.const_defined? :LEGACY_NAMES
+
+      @klass::LEGACY_NAMES
+    end
   end
 
   class ServiceDefinition < StructDefinition
@@ -40,6 +46,12 @@ module Thrift
 
     def service
       @klass::SERVICE
+    end
+
+    def legacy_names
+      return [] unless @klass.const_defined? :LEGACY_NAMES
+
+      @klass::LEGACY_NAMES
     end
 
     def service_type

--- a/lib/rb/lib/thrift/exceptions.rb
+++ b/lib/rb/lib/thrift/exceptions.rb
@@ -27,6 +27,18 @@ module Thrift
     attr_reader :message
   end
 
+  class ClientNotDefined < Exception
+    def initialize
+      super('client not defined')
+    end
+  end
+
+  class ProcessorNotDefined < Exception
+    def initialize
+      super('client not defined')
+    end
+  end
+
   class ApplicationException < Exception
 
     UNKNOWN = 0

--- a/lib/rb/lib/thrift/processor.rb
+++ b/lib/rb/lib/thrift/processor.rb
@@ -174,4 +174,23 @@ module Thrift
       oprot.trans.flush
     end
   end
+
+  class << self
+    def build_processor_from_provider(klass, provider, handler)
+      sdef = ServiceDefinition.new(klass)
+
+      [
+        { namespace: sdef.namespace, service: sdef.service },
+        *sdef.legacy_names
+      ].reduce(nil) do |acc, n|
+        acc || begin
+          provider.build(
+            n[:namespace], n[:service], sdef.processor_class, handler
+          )
+        rescue ProcessorNotDefined
+          nil
+        end
+      end || raise(ProcessorNotDefined)
+    end
+  end
 end


### PR DESCRIPTION
The thrift `*` namespace  and service name has became a crucial part of our infrastructure as it is used in the service discovery process. We lost the ability to reshuffle/rename our interface repo.

This PR aims at providing a way to handle gracefully the change of namespace or service name.

This adds two directives to the thrift grammar

1 - `previously_known_as`

The entire program as been renamed 

```
namespace * foo.v1.bar

previously_known_as foo.bar

service Buz {}
```

It means that our SD system will be called for `foo.v1.bar.Buz` first and if no match is found, `foo.bar.Buz` will be inquired

2 - `@previously_known_as`

Only a service or a struct has been moved

```
namespace * foo.v1.bar

service Baz {}

@previously_known_as{namespace="foo.bar",name="Buzz"}
service Buz {}
```

It allows finer grained control over the rewrite.


